### PR TITLE
Added the option to disable the search container

### DIFF
--- a/src/newtab/scripts/config.ts
+++ b/src/newtab/scripts/config.ts
@@ -52,6 +52,7 @@ export const defaultConfig: Config = {
     type: "animate-up-bouncy"
   },
   search: {
+    enabled: true,
     font: `"Jetbrains-Mono-Regular-Fixed"`,
     textColor: "#ffffff",
     placeholderText: "search...",
@@ -147,13 +148,14 @@ export interface Config {
     enabled: boolean;
     bookmarkTiming: BookmarkTiming;
     type:
-      | "animate-down-bouncy"
-      | "animate-down-smooth"
-      | "animate-down-fall"
-      | "animate-up-bouncy"
-      | "animate-up-smooth";
+    | "animate-down-bouncy"
+    | "animate-down-smooth"
+    | "animate-down-fall"
+    | "animate-up-bouncy"
+    | "animate-up-smooth";
   };
   search: {
+    enabled: boolean;
     font: string;
     textColor: string;
     placeholderText: string;

--- a/src/newtab/scripts/load-page.ts
+++ b/src/newtab/scripts/load-page.ts
@@ -31,6 +31,7 @@ export const loadPage = () => {
 
     setSearchStuff(config.search.font, config.search.placeholderText);
     styleSearch(
+      config.search.enabled,
       config.ui.style,
       config.search.textColor,
       config.search.placeholderTextColor,

--- a/src/newtab/scripts/utils/style-search.ts
+++ b/src/newtab/scripts/utils/style-search.ts
@@ -2,11 +2,16 @@ import { UIStyle } from "src/newtab/scripts/config";
 import { searchContainerEl, searchInputEl } from "src/newtab/scripts/ui";
 
 export const styleSearch = (
+  enabled: boolean,
   style: UIStyle,
   textColor: string,
   placeholderTextColor: string,
   foregroundColor: string
 ) => {
+  if (!enabled) {
+    searchContainerEl.classList.add("hidden");
+  }
+
   searchInputEl.style.color = textColor;
 
   const placeholderTextColorCss = `

--- a/src/options.html
+++ b/src/options.html
@@ -306,6 +306,17 @@
           <span class="text-neutral-500 text-base">search</span>
           <div class="bg-neutral-500 h-[1px] rounded-md my-auto"></div>
         </div>
+        <div class="grid grid-cols-[max-content_auto] w-full place-items-center">
+          <p class="text-white text-base">search.enabled</p>
+          <div class="ml-auto">
+            <label class="relative inline-flex items-center cursor-pointer">
+              <input id="search-enabled-checkbox" type="checkbox" value="" class="sr-only peer" />
+              <div
+                class="w-11 h-6 peer bg-neutral-800 outline-none rounded-full peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-[3px] after:left-[3px] after:bg-neutral-700 after:border-none after:rounded-full after:h-[1.15rem] after:aspect-square after:transition-all peer-checked:bg-emerald-500 peer-checked:after:bg-white">
+              </div>
+            </label>
+          </div>
+        </div>
         <div class="grid gap-2">
           <p class="text-white text-base">search.font</p>
           <div id="search-font-container"

--- a/src/options/scripts/ui.ts
+++ b/src/options/scripts/ui.ts
@@ -84,6 +84,8 @@ export const searchEngineEcosiaButtonEl = document.getElementById("search-engine
 export const searchFocusedBorderColorContainerEl = document.getElementById("search-focused-border-color-container") as HTMLDivElement;
 export const searchFocusedBorderColorInputEl = document.getElementById("search-focused-border-color-input") as HTMLInputElement;
 
+export const searchEnabledCheckboxEl = document.getElementById("search-enabled-checkbox") as HTMLInputElement;
+
 export const hotkeysEnabledCheckboxEl = document.getElementById("hotkeys-enabled-checkbox") as HTMLInputElement;
 
 export const bookmarksTypeDefaultButtonEl = document.getElementById("bookmarks-type-default-button") as HTMLButtonElement;
@@ -127,15 +129,15 @@ export const inputs: Input[] = [
   },
   {
     container: searchFontContainerEl,
-    input: searchFontInputEl 
+    input: searchFontInputEl
   },
   {
     container: searchPlaceholderTextContainerEl,
-    input: searchPlaceholderTextInputEl 
+    input: searchPlaceholderTextInputEl
   },
   {
     container: searchFocusedBorderColorContainerEl,
-    input: searchFocusedBorderColorInputEl 
+    input: searchFocusedBorderColorInputEl
   }
 ];
 
@@ -157,7 +159,7 @@ export const buttonSwitches: ButtonSwitch[] = [
       messageTypeTime24ButtonEl,
       messageTypeCustomButtonEl
     ],
-    attr: "message-type" 
+    attr: "message-type"
   },
   {
     buttons: [

--- a/src/options/scripts/utils/fill-helpers/fill-search.ts
+++ b/src/options/scripts/utils/fill-helpers/fill-search.ts
@@ -12,7 +12,8 @@ import {
   searchEngineStartpageButtonEl,
   searchEngineEcosiaButtonEl,
   searchTextColorInputEl,
-  searchPlaceholderTextColorInputEl
+  searchPlaceholderTextColorInputEl,
+  searchEnabledCheckboxEl
 } from "src/options/scripts/ui";
 
 export const fillSearchInputs = (config: Config) => {
@@ -57,4 +58,5 @@ export const fillSearchInputs = (config: Config) => {
   }
 
   searchFocusedBorderColorInputEl.value = config.search.focusedBorderColor;
+  searchEnabledCheckboxEl.checked = config.search.enabled;
 };

--- a/src/options/scripts/utils/save-helpers/save-search.ts
+++ b/src/options/scripts/utils/save-helpers/save-search.ts
@@ -1,5 +1,6 @@
 import { Config } from "src/newtab/scripts/config";
 import {
+  searchEnabledCheckboxEl,
   searchFocusedBorderColorInputEl,
   searchFontInputEl,
   searchPlaceholderTextColorInputEl,
@@ -8,6 +9,7 @@ import {
 } from "src/options/scripts/ui";
 
 export const saveSearchSettingsToDraft = (draft: Config) => {
+  draft.search.enabled = searchEnabledCheckboxEl.checked;
   draft.search.font = searchFontInputEl.value;
   draft.search.textColor = searchTextColorInputEl.value;
   draft.search.placeholderText = searchPlaceholderTextInputEl.value;


### PR DESCRIPTION
Idea was taken from a 4 star review of the extension on the FireFox addons page by user 17422434 who stated "I love this addon, but I wish there was a way to hide the search bar". 

Well, I added just that, this time without the help of ChatGPT 4-o!
Super proud of myself, as this is my first time ever working in an extension, but I figured it out!