### PR TITLE
prevent search trigger during IME composition

### DIFF
--- a/src/newtab/scripts/keys.ts
+++ b/src/newtab/scripts/keys.ts
@@ -126,6 +126,21 @@ export const listenToKeys = (config: Config) => {
     // if (e.key === "K") navigateTab("right");
   });
 
+  let isComposing = false;
+
+  function addCompositionListeners(element: HTMLElement) {
+    element.addEventListener("compositionstart", () => {
+      isComposing = true;
+    });
+
+    element.addEventListener("compositionend", () => {
+      isComposing = false;
+    });
+  }
+
+  addCompositionListeners(searchInputEl);
+  addCompositionListeners(bookmarkSearchInputEl);
+
   searchInputEl.addEventListener("blur", () => {
     // prevent getting unfocused on window unfocus
     if (document.hasFocus()) unfocusSearch();
@@ -133,11 +148,12 @@ export const listenToKeys = (config: Config) => {
 
   searchInputEl.addEventListener("focus", (e) => focusSearch(config, e));
 
-  searchInputEl.addEventListener("keyup", (e) => {
+  searchInputEl.addEventListener("keydown", (e) => {
     if (e.key === "Enter") {
       e.preventDefault();
 
-      if (searchInputEl.value === "") return;
+      // do not search if composition is still in progress
+      if (isComposing || searchInputEl.value === "") return;
 
       // open in new tab if ctrl
       if (e.ctrlKey) {
@@ -165,7 +181,7 @@ export const listenToKeys = (config: Config) => {
 
   bookmarkSearchInputEl.addEventListener("focus", (e) => focusBookmarkSearch(config, e));
 
-  bookmarkSearchInputEl.addEventListener("keyup", (e) => {
+  bookmarkSearchInputEl.addEventListener("keydown", (e) => {
     enableSearchBookmark(
       bookmarks,
       config.bookmarks.type,
@@ -180,7 +196,7 @@ export const listenToKeys = (config: Config) => {
       const resultIndex = parseInt(bookmarkSearchResultsContainerEl.getAttribute("selected-index") as string);
       // prettier-ignore
       const bookmarkUrl = bookmarkSearchResultsContainerEl.children[resultIndex].getAttribute("bookmark-result-url") as string;
-      if (!bookmarkUrl) return;
+      if (isComposing || !bookmarkUrl) return;
 
       // open in new tab if ctrl
       if (e.ctrlKey) {

--- a/src/newtab/scripts/keys.ts
+++ b/src/newtab/scripts/keys.ts
@@ -181,14 +181,16 @@ export const listenToKeys = (config: Config) => {
 
   bookmarkSearchInputEl.addEventListener("focus", (e) => focusBookmarkSearch(config, e));
 
-  bookmarkSearchInputEl.addEventListener("keydown", (e) => {
+  bookmarkSearchInputEl.addEventListener("keyup", (e) => {
     enableSearchBookmark(
       bookmarks,
       config.bookmarks.type,
       config.search.textColor,
       config.search.placeholderTextColor
     );
+  });
 
+  bookmarkSearchInputEl.addEventListener("keydown", (e) => {
     if (e.key === "Enter" && !e.repeat) {
       e.preventDefault();
 

--- a/src/newtab/scripts/keys.ts
+++ b/src/newtab/scripts/keys.ts
@@ -149,7 +149,7 @@ export const listenToKeys = (config: Config) => {
   searchInputEl.addEventListener("focus", (e) => focusSearch(config, e));
 
   searchInputEl.addEventListener("keydown", (e) => {
-    if (e.key === "Enter") {
+    if (e.key === "Enter" && !e.repeat) {
       e.preventDefault();
 
       // do not search if composition is still in progress
@@ -189,7 +189,7 @@ export const listenToKeys = (config: Config) => {
       config.search.placeholderTextColor
     );
 
-    if (e.key === "Enter") {
+    if (e.key === "Enter" && !e.repeat) {
       e.preventDefault();
 
       // prettier-ignore


### PR DESCRIPTION
### Overview:

This PR modifies the behavior of `searchInputEl` and `bookmarkSearchInputEl` to enhance the user experience when using input methods that require character selection, such as those used for Chinese or Japanese.

### Changes Made:

- When users type in searchInputEl or bookmarkSearchInputEl, if an underline appears (indicating that character selection is in progress), pressing the Enter key will not immediately trigger a search but will allow the selection of candidates.
- When there is no underline, pressing the Enter key will trigger the search function.

### Compare:

- before

https://github.com/user-attachments/assets/f91e44d7-fdff-4eb7-b9dd-82d31f758108

- after

https://github.com/user-attachments/assets/1abcdc21-a6b9-4bd7-8af8-09c8534d184d
